### PR TITLE
Apply retry when the response is a "too many requests"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `429 Too Many Requests` errors are now retried when using `Innmind\HttpTransport\ExponentialBackoff`
+
 ## 7.2.1 - 2024-03-01
 
 ### Fixed

--- a/src/ExponentialBackoff.php
+++ b/src/ExponentialBackoff.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Innmind\HttpTransport;
 
 use Innmind\Http\Request;
+use Innmind\Http\Response\StatusCode;
 use Innmind\TimeContinuum\{
     Period,
     Earth\Period\Millisecond,
@@ -74,6 +75,8 @@ final class ExponentialBackoff implements Transport
         Period $period,
     ): Either {
         return $result->otherwise(fn($error) => match (true) {
+            $error instanceof ClientError &&
+            $error->response()->statusCode() === StatusCode::tooManyRequests => $this->retry($request, $period),
             $error instanceof ServerError => $this->retry($request, $period),
             $error instanceof ConnectionFailed => $this->retry($request, $period),
             default => $this->return($error),


### PR DESCRIPTION
## Problem

Initially this client didn't apply the retry mechanism for any _client error_ since the client should _change_ the request. However the `429 too many requests` client error is a safe to retry after a grace period.

## Solution

Apply the retry for `429` response errors