### PR TITLE
Exclude `innmind/url` versions with broken path resolving

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ramsey/uuid": "^4.7",
         "innmind/time": "~1.0",
         "innmind/immutable": "~6.0",
-        "innmind/url": "~5.0",
+        "innmind/url": "5.0.0|^5.2.1",
         "innmind/io": "~4.0"
     },
     "autoload": {


### PR DESCRIPTION
Fix #27 