### PR TITLE
Drop PHP `8.4` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Requires PHP `8.5`
+
 ## 9.1.0 - 2026-04-09
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "http://github.com/Innmind/HttpTransport/issues"
     },
     "require": {
-        "php": "~8.4",
+        "php": "~8.5",
         "ext-curl": "*",
         "innmind/http": "~9.0",
         "innmind/filesystem": "~9.0",

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,7 +14,4 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
-    <issueHandlers>
-        <UndefinedAttributeClass errorLevel="suppress" />
-    </issueHandlers>
 </psalm>

--- a/tests/CurlTest.php
+++ b/tests/CurlTest.php
@@ -19,6 +19,8 @@ use Innmind\Http\{
     Method,
     ProtocolVersion,
     Headers,
+    Header,
+    Header\Value,
     Header\Date,
     Header\Location,
 };
@@ -503,6 +505,9 @@ class CurlTest extends TestCase
                 Url::of("https://http$server.org/delay/2"),
                 Method::get,
                 ProtocolVersion::v11,
+                Headers::of(
+                    Header::of('User-Agent', Value::of('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5.2 Safari/605.1.15')),
+                )
             );
 
             $result = ($this->curl)($request)->match(

--- a/tests/CurlTest.php
+++ b/tests/CurlTest.php
@@ -498,16 +498,17 @@ class CurlTest extends TestCase
         $this->assertSame($initialCount, \count(\get_resources('stream')));
     }
 
+    #[\PHPUnit\Framework\Attributes\Group('wip')]
     public function testTimeout()
     {
+        $userAgent = Header::of('User-Agent', Value::of('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5.2 Safari/605.1.15'));
+
         foreach (['bin', 'bun'] as $server) {
             $request = Request::of(
                 Url::of("https://http$server.org/delay/2"),
                 Method::get,
                 ProtocolVersion::v11,
-                Headers::of(
-                    Header::of('User-Agent', Value::of('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5.2 Safari/605.1.15')),
-                )
+                Headers::of($userAgent),
             );
 
             $result = ($this->curl)($request)->match(
@@ -528,6 +529,7 @@ class CurlTest extends TestCase
             ProtocolVersion::v11,
             Headers::of(
                 Timeout::of(1),
+                $userAgent,
             ),
         );
 

--- a/tests/CurlTest.php
+++ b/tests/CurlTest.php
@@ -19,8 +19,6 @@ use Innmind\Http\{
     Method,
     ProtocolVersion,
     Headers,
-    Header,
-    Header\Value,
     Header\Date,
     Header\Location,
 };
@@ -532,14 +530,11 @@ class CurlTest extends TestCase
     #[Group('local')]
     public function testTimeout()
     {
-        $userAgent = Header::of('User-Agent', Value::of('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5.2 Safari/605.1.15'));
-
         foreach (['bin', 'bun'] as $server) {
             $request = Request::of(
                 Url::of("https://http$server.org/delay/2"),
                 Method::get,
                 ProtocolVersion::v11,
-                Headers::of($userAgent),
             );
 
             $result = ($this->curl)($request)->match(
@@ -560,7 +555,6 @@ class CurlTest extends TestCase
             ProtocolVersion::v11,
             Headers::of(
                 Timeout::of(1),
-                $userAgent,
             ),
         );
 


### PR DESCRIPTION
Since the latest version of `innmind/url` requires `8.5` essentially all packages for `innmind/foundation` can move to `8.5` as well.