### PR TITLE
Exclude timeout test from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
   coverage:
     uses: innmind/github-workflows/.github/workflows/coverage-matrix.yml@main
     secrets: inherit
+    with:
+      tags: ci
   psalm:
     uses: innmind/github-workflows/.github/workflows/psalm-matrix.yml@main
   cs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     uses: innmind/github-workflows/.github/workflows/black-box-matrix.yml@main
     with:
       scenarii: 20
+      tags: ci
   coverage:
     uses: innmind/github-workflows/.github/workflows/coverage-matrix.yml@main
     secrets: inherit

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,6 @@
     "require-dev": {
         "innmind/static-analysis": "~1.3",
         "innmind/coding-standard": "~2.0",
-        "innmind/black-box": "~6.5"
+        "innmind/black-box": "~6.12"
     }
 }

--- a/tests/CircuitBreakerTest.php
+++ b/tests/CircuitBreakerTest.php
@@ -24,10 +24,15 @@ use Innmind\Time\{
     Period,
 };
 use Innmind\Immutable\Either;
-use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use Innmind\BlackBox\PHPUnit\Framework\{
+    TestCase,
+    Attributes\Group,
+};
 
 class CircuitBreakerTest extends TestCase
 {
+    #[Group('local')]
+    #[Group('ci')]
     public function testDoesntOpenCircuitOnSuccessfulResponse()
     {
         $request = Request::of(
@@ -51,6 +56,8 @@ class CircuitBreakerTest extends TestCase
         $this->assertEquals($expected, $fulfill($request));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testDoesntOpenCircuitOnRedirectionResponse()
     {
         $request = Request::of(
@@ -74,6 +81,8 @@ class CircuitBreakerTest extends TestCase
         $this->assertEquals($expected, $fulfill($request));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testDoesntOpenCircuitOnClientErrorResponse()
     {
         $request = Request::of(
@@ -97,6 +106,8 @@ class CircuitBreakerTest extends TestCase
         $this->assertEquals($expected, $fulfill($request));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testOpenCircuitOnServerError()
     {
         $request = Request::of(
@@ -125,6 +136,8 @@ class CircuitBreakerTest extends TestCase
         ));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testOpenCircuitOnConnectionFailure()
     {
         $request = Request::of(
@@ -149,6 +162,8 @@ class CircuitBreakerTest extends TestCase
         ));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testOpenCircuitOnlyForTheDomainThatFailed()
     {
         $request1 = Request::of(
@@ -185,6 +200,8 @@ class CircuitBreakerTest extends TestCase
         $this->assertEquals($expected2, $fulfill($request2));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testRecloseTheCircuitAfterTheSpecifiedDelay()
     {
         $request = Request::of(

--- a/tests/ClientErrorTest.php
+++ b/tests/ClientErrorTest.php
@@ -13,10 +13,15 @@ use Innmind\Http\{
 };
 use Innmind\Url\Url;
 use Innmind\Immutable\Sequence;
-use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use Innmind\BlackBox\PHPUnit\Framework\{
+    TestCase,
+    Attributes\Group,
+};
 
 class ClientErrorTest extends TestCase
 {
+    #[Group('local')]
+    #[Group('ci')]
     public function testAcceptClientErrorfulResponses()
     {
         $_ = Sequence::of(...StatusCode::cases())
@@ -38,6 +43,8 @@ class ClientErrorTest extends TestCase
             });
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testRejectOtherKindOfResponse()
     {
         $_ = Sequence::of(...StatusCode::cases())

--- a/tests/CurlTest.php
+++ b/tests/CurlTest.php
@@ -43,6 +43,7 @@ use Innmind\Immutable\{
 };
 use Innmind\BlackBox\{
     PHPUnit\Framework\TestCase,
+    PHPUnit\Framework\Attributes\Group,
     PHPUnit\BlackBox,
     Set,
 };
@@ -58,6 +59,8 @@ class CurlTest extends TestCase
         $this->curl = Transport::curl(Clock::live());
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testOkResponse()
     {
         $success = ($this->curl)(Request::of(
@@ -83,6 +86,8 @@ class CurlTest extends TestCase
         );
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testRedirection()
     {
         $redirection = ($this->curl)(Request::of(
@@ -109,6 +114,8 @@ class CurlTest extends TestCase
         );
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testClientError()
     {
         $error = ($this->curl)(Request::of(
@@ -135,6 +142,8 @@ class CurlTest extends TestCase
         );
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testFailure()
     {
         $error = ($this->curl)($request = Request::of(
@@ -157,6 +166,8 @@ class CurlTest extends TestCase
         );
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testResponseBody()
     {
         $success = ($this->curl)(Request::of(
@@ -208,6 +219,8 @@ class CurlTest extends TestCase
         );
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testHead()
     {
         $success = ($this->curl)(Request::of(
@@ -227,6 +240,8 @@ class CurlTest extends TestCase
         );
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testPost(): BlackBox\Proof
     {
         return $this
@@ -268,6 +283,8 @@ class CurlTest extends TestCase
             });
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testPostLargeContent()
     {
         // The file is a bit more than 2Mo, so if everything was kept in memory
@@ -304,6 +321,8 @@ class CurlTest extends TestCase
             ->megaBytes(3);
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testMinorVersionOfProtocolMayNotBePresent()
     {
         // Packagist respond with HTTP/2 instead of HTTP/2.0
@@ -320,6 +339,8 @@ class CurlTest extends TestCase
         $this->assertSame(ProtocolVersion::v20, $success->protocolVersion());
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testConcurrency()
     {
         $request = Request::of(
@@ -355,6 +376,8 @@ class CurlTest extends TestCase
             ->seconds((int) \ceil(2 * $forOneRequest));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testMaxConcurrency()
     {
         $curl = $this->curl->map(static fn($config) => $config->limitConcurrencyTo(1));
@@ -395,6 +418,8 @@ class CurlTest extends TestCase
             ->seconds((int) (2 * $forOneRequest));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testHeartbeat()
     {
         $heartbeat = 0;
@@ -419,6 +444,8 @@ class CurlTest extends TestCase
         $this->assertGreaterThan(1, $heartbeat);
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testOutOfOrderUnwrapWithMaxConcurrency()
     {
         $curl = $this->curl->map(static fn($config) => $config->limitConcurrencyTo(2));
@@ -444,6 +471,8 @@ class CurlTest extends TestCase
         );
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testSubsequentRequestsAreCalledCorrectlyInsideFlatMaps()
     {
         $curl = $this->curl->map(static fn($config) => $config->limitConcurrencyTo(2));
@@ -471,6 +500,8 @@ class CurlTest extends TestCase
         );
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testReleaseResources()
     {
         $initialCount = \count(\get_resources('stream'));
@@ -496,6 +527,7 @@ class CurlTest extends TestCase
         $this->assertSame($initialCount, \count(\get_resources('stream')));
     }
 
+    #[Group('local')]
     public function testTimeout()
     {
         foreach (['bin', 'bun'] as $server) {

--- a/tests/ExponentialBackoffTest.php
+++ b/tests/ExponentialBackoffTest.php
@@ -31,10 +31,15 @@ use Innmind\Immutable\{
     Attempt,
     SideEffect,
 };
-use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use Innmind\BlackBox\PHPUnit\Framework\{
+    TestCase,
+    Attributes\Group,
+};
 
 class ExponentialBackoffTest extends TestCase
 {
+    #[Group('local')]
+    #[Group('ci')]
     public function testDoesntRetryWhenInformationResponseOnFirstCall()
     {
         $request = Request::of(
@@ -56,6 +61,8 @@ class ExponentialBackoffTest extends TestCase
         $this->assertEquals($expected, $fulfill($request));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testDoesntRetryWhenSuccessfulResponseOnFirstCall()
     {
         $request = Request::of(
@@ -77,6 +84,8 @@ class ExponentialBackoffTest extends TestCase
         $this->assertEquals($expected, $fulfill($request));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testDoesntRetryWhenRedirectionResponseOnFirstCall()
     {
         $request = Request::of(
@@ -98,6 +107,8 @@ class ExponentialBackoffTest extends TestCase
         $this->assertEquals($expected, $fulfill($request));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testDoesntRetryWhenClientErrorResponseOnFirstCall()
     {
         $request = Request::of(
@@ -119,6 +130,8 @@ class ExponentialBackoffTest extends TestCase
         $this->assertEquals($expected, $fulfill($request));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testDoesntRetryWhenMalformedResponseOnFirstCall()
     {
         $request = Request::of(
@@ -136,6 +149,8 @@ class ExponentialBackoffTest extends TestCase
         $this->assertEquals($expected, $fulfill($request));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testDoesntRetryWhenFailureOnFirstCall()
     {
         $request = Request::of(
@@ -153,6 +168,8 @@ class ExponentialBackoffTest extends TestCase
         $this->assertEquals($expected, $fulfill($request));
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testRetryWhileThereIsStillATooManyRequestsError()
     {
         $request = Request::of(
@@ -195,6 +212,8 @@ class ExponentialBackoffTest extends TestCase
         $this->assertSame(12, $calls);
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testRetryWhileThereIsStillAServerError()
     {
         $request = Request::of(
@@ -237,6 +256,8 @@ class ExponentialBackoffTest extends TestCase
         $this->assertSame(12, $calls);
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testRetryWhileThereIsStillAConnectionFailure()
     {
         $request = Request::of(
@@ -275,6 +296,8 @@ class ExponentialBackoffTest extends TestCase
         $this->assertSame(12, $calls);
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testStopRetryingWhenNoLongerReceivingAServerError()
     {
         $request = Request::of(
@@ -317,6 +340,8 @@ class ExponentialBackoffTest extends TestCase
         $this->assertSame(2, $calls);
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testByDefaultRetriesFiveTimesByUsingAPowerOfE()
     {
         $request = Request::of(

--- a/tests/FollowRedirectionsTest.php
+++ b/tests/FollowRedirectionsTest.php
@@ -31,6 +31,7 @@ use Innmind\Url\{
 use Innmind\Immutable\Either;
 use Innmind\BlackBox\{
     PHPUnit\Framework\TestCase,
+    PHPUnit\Framework\Attributes\Group,
     PHPUnit\BlackBox,
     Set,
 };
@@ -40,6 +41,8 @@ class FollowRedirectionsTest extends TestCase
 {
     use BlackBox;
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testDoesntModifyNonRedirectionResults(): BlackBox\Proof
     {
         $request = Request::of(
@@ -98,6 +101,8 @@ class FollowRedirectionsTest extends TestCase
             });
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testRedirectMaximum5Times(): BlackBox\Proof
     {
         return $this
@@ -155,6 +160,8 @@ class FollowRedirectionsTest extends TestCase
             });
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testDoesntRedirectWhenNoLocationHeader(): BlackBox\Proof
     {
         return $this
@@ -196,6 +203,8 @@ class FollowRedirectionsTest extends TestCase
             });
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testRedirectSeeOther(): BlackBox\Proof
     {
         return $this
@@ -270,6 +279,8 @@ class FollowRedirectionsTest extends TestCase
             });
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testRedirect(): BlackBox\Proof
     {
         return $this
@@ -350,6 +361,8 @@ class FollowRedirectionsTest extends TestCase
             });
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testDoesntRedirectUnsafeMethods(): BlackBox\Proof
     {
         return $this

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -18,7 +18,10 @@ use Innmind\Http\{
 };
 use Innmind\Url\Url;
 use Psr\Log\NullLogger;
-use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use Innmind\BlackBox\PHPUnit\Framework\{
+    TestCase,
+    Attributes\Group,
+};
 
 class LoggerTest extends TestCase
 {
@@ -32,6 +35,8 @@ class LoggerTest extends TestCase
         );
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testFulfill()
     {
         $request = Request::of(

--- a/tests/RedirectionTest.php
+++ b/tests/RedirectionTest.php
@@ -13,10 +13,15 @@ use Innmind\Http\{
 };
 use Innmind\Url\Url;
 use Innmind\Immutable\Sequence;
-use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use Innmind\BlackBox\PHPUnit\Framework\{
+    TestCase,
+    Attributes\Group,
+};
 
 class RedirectionTest extends TestCase
 {
+    #[Group('local')]
+    #[Group('ci')]
     public function testAcceptRedirectionfulResponses()
     {
         $_ = Sequence::of(...StatusCode::cases())
@@ -38,6 +43,8 @@ class RedirectionTest extends TestCase
             });
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testRejectOtherKindOfResponse()
     {
         $_ = Sequence::of(...StatusCode::cases())

--- a/tests/ServerErrorTest.php
+++ b/tests/ServerErrorTest.php
@@ -13,10 +13,15 @@ use Innmind\Http\{
 };
 use Innmind\Url\Url;
 use Innmind\Immutable\Sequence;
-use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use Innmind\BlackBox\PHPUnit\Framework\{
+    TestCase,
+    Attributes\Group,
+};
 
 class ServerErrorTest extends TestCase
 {
+    #[Group('local')]
+    #[Group('ci')]
     public function testAcceptServerErrorfulResponses()
     {
         $_ = Sequence::of(...StatusCode::cases())
@@ -38,6 +43,8 @@ class ServerErrorTest extends TestCase
             });
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testRejectOtherKindOfResponse()
     {
         $_ = Sequence::of(...StatusCode::cases())

--- a/tests/SuccessTest.php
+++ b/tests/SuccessTest.php
@@ -17,6 +17,8 @@ use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
 class SuccessTest extends TestCase
 {
+    #[Group('local')]
+    #[Group('ci')]
     public function testAcceptSuccessfulResponses()
     {
         $_ = Sequence::of(...StatusCode::cases())
@@ -38,6 +40,8 @@ class SuccessTest extends TestCase
             });
     }
 
+    #[Group('local')]
+    #[Group('ci')]
     public function testRejectOtherKindOfResponse()
     {
         $_ = Sequence::of(...StatusCode::cases())

--- a/tests/SuccessTest.php
+++ b/tests/SuccessTest.php
@@ -13,7 +13,10 @@ use Innmind\Http\{
 };
 use Innmind\Url\Url;
 use Innmind\Immutable\Sequence;
-use Innmind\BlackBox\PHPUnit\Framework\TestCase;
+use Innmind\BlackBox\PHPUnit\Framework\{
+    TestCase,
+    Attributes\Group,
+};
 
 class SuccessTest extends TestCase
 {


### PR DESCRIPTION
This is due to the timeout test to be flaky as it relies on an external service that often fails. Instead of deleting it, it's just not run in the CI to prevent PRs to be merged. And it can still be run locally.